### PR TITLE
Add RustChain MCP to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The agent economy is here. These projects put real money (or tokens) behind real
 | Project | Token/Currency | Bounty Range | Focus | Link |
 |---------|---------------|-------------|-------|------|
 | **[Beacon](https://github.com/Scottcjn/beacon-skill)** | RTC | 10-150 RTC | Agent discovery and coordination protocol | [Bounties](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aopen+beacon) |
+| **[RustChain MCP](https://github.com/Scottcjn/rustchain-mcp)** | RTC | 5-100 RTC | MCP server for RustChain and BoTTube tools | [Bounties](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aopen+MCP) |
 | **[Cline](https://github.com/cline/cline)** | USD | $1M pool | AI coding assistant (from OpenClaw grant) | [Grants](https://cline.bot/blog/clawcon-sf-clines-1m-open-source-grant-meets-openclaw-builders) |
 | **[tea.xyz](https://tea.xyz)** | TEA | Varies | Package manager with OSS incentives | [Protocol](https://tea.xyz) |
 | **[Algora](https://algora.io)** | USD | Varies | Open source bounty platform | [Bounties](https://algora.io/bounties) |


### PR DESCRIPTION
Closes #3

## Summary
- add RustChain MCP to the Developer Tools table
- link to the public RustChain bounty board
- keep the diff to a single README row

## Qualification notes
RustChain MCP appears to meet the repo requirements for listing:
- open source repo: https://github.com/Scottcjn/rustchain-mcp
- public issue tracker / bounty board: https://github.com/Scottcjn/rustchain-bounties/issues
- 3+ public payout records tied to the project
  - rustchain-bounties#1152: owner comment says "100 RTC paid"
  - rustchain-bounties#2302: owner comment says "Payment: 75 RTC"
  - rustchain-bounties#104 ledger includes a rustchain-mcp payout entry for bounty #1591 / rustchain-mcp #6

## Verification
- git diff --check

Wallet name: ukgorclawbot-stack