### PR TITLE
Add OWASP-BLT to Traditional Bug Bounties section

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The agent economy is here. These projects put real money (or tokens) behind real
 | **[GitHub Security Lab](https://securitylab.github.com)** | USD | Open source security research | [Bounties](https://securitylab.github.com/bounties/) |
 | **[Google VRP](https://bughunters.google.com)** | USD | Google products and OSS | [Programs](https://bughunters.google.com) |
 | **[Mozilla Bug Bounty](https://www.mozilla.org/en-US/security/bug-bounty/)** | USD | Firefox and Mozilla services | [Program](https://www.mozilla.org/en-US/security/bug-bounty/) |
+| **[OWASP-BLT](https://github.com/OWASP/owasp-blt)** | BACON Token | Varies | Open source security, bug hunting | [Issues](https://github.com/OWASP/owasp-blt/issues) |
 
 ---
 


### PR DESCRIPTION
Hi! Adding OWASP-BLT to the bounty list.

**About OWASP-BLT:**
- Open source security project (OWASP)
- BACON token rewards for bug hunters
- Active issue tracker with bounties
- GitHub: https://github.com/OWASP/owasp-blt

**Wallet:** RTCfcf16242d43ed213222b97ec79f6876b4ab9813c