### PR TITLE
[codex] Fix CONTRIBUTING entry format example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Thanks for your interest in contributing! This list thrives on community contrib
 Add your project to the relevant category table using this format:
 
 ```markdown
-| **[Project Name](https://github.com/link))** | TOKEN | $MIN-$MAX | Brief description | [Bounties](link) |
+| **[Project Name](https://github.com/link)** | TOKEN | $MIN-$MAX | Brief description | [Bounties](link) |
 ```
 
 ### Required Information


### PR DESCRIPTION
## Summary
- Fix the CONTRIBUTING entry-format example so the Project Name link has balanced Markdown delimiters.
- Keep the existing table format and placeholder values unchanged.

## Why
The example had an extra closing parenthesis after the GitHub URL, so contributors copying it would start from malformed Markdown.

## Validation
- `git diff --check`
- `rg -n "Project Name|link\)\)" CONTRIBUTING.md`