### PR TITLE
docs: fix OpenPango bounty link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The agent economy is here. These projects put real money (or tokens) behind real
 
 | Project | Token/Currency | Bounty Range | Focus | Link |
 |---------|---------------|-------------|-------|------|
-| **[OpenPango](https://github.com/openpango)** | SOL | Varies | AI agent skills marketplace | [Bounties](https://github.com/openpango/openpango-skills/issues) |
+| **[OpenPango](https://github.com/openpango)** | SOL | Varies | AI agent skills marketplace | [Bounties](https://github.com/openpango/openpango/issues) |
 | **[bounty.new](https://bounty.new)** | USD/Crypto | Varies | Bounty creation platform | [Bounties](https://bounty.new) |
 | **[ShaprAI](https://github.com/Scottcjn/shaprai)** | RTC | 5-50 RTC | Agent sharpener framework | [Bounties](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aopen+shaprai) |
 


### PR DESCRIPTION
Summary:
- Update the README OpenPango bounty link from the deleted openpango-skills issues URL to the live openpango/openpango issues page.
- Keep the scope to README.md only for rustchain-bounties#9018.

Validation:
- curl old https://github.com/openpango/openpango-skills/issues -> HTTP 404
- curl new https://github.com/openpango/openpango/issues -> HTTP 200
- git diff --check
- codespell README.md

Bounty: Scottcjn/rustchain-bounties#9018
RTC receive address: RTC991843db74121688c427d42ad7799a21e9d8adc2
Payment details are handled only through the public bounty workflow.