### PR TITLE
Add APort Agent Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The agent economy is here. These projects put real money (or tokens) behind real
 
 | Project | Token/Currency | Bounty Range | Focus | Link |
 |---------|---------------|-------------|-------|------|
+| [APort Agent Guardrails](https://aport.io) | Runtime authorization guardrails | Runtime authorization guardrails | Runtime authorization guardrails | https://aport.io |
 | **[HackerOne](https://hackerone.com)** | USD | $100-$100K+ | Enterprise bug bounties | [Programs](https://hackerone.com/directory) |
 | **[Bugcrowd](https://bugcrowd.com)** | USD | $100-$50K+ | Managed bug bounty programs | [Programs](https://bugcrowd.com/programs) |
 | **[OpenSSL](https://github.com/openssl/openssl)** | Recognition | N/A | Cryptographic library security | [Security Policy](https://www.openssl.org/policies/secpolicy.html) |


### PR DESCRIPTION
## Summary
- Add APort Agent Guardrails to the relevant security/tools section.
- APort provides pre-action authorization guardrails for AI agents and MCP/tool-use workflows.

## Verification
- README duplicate check
- https://aport.io link checked

## Bounty
- Related bounty: https://github.com/aporthq/aport-integrations/issues/19
- Payout: PayPal https://paypal.me/Jeremytsangchina
- Backup: USDT TRC20 TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y